### PR TITLE
Specify own workdir for dev-perl/perl-URxvt

### DIFF
--- a/dev-perl/perl-URxvt/perl-URxvt-2.2-r1.ebuild
+++ b/dev-perl/perl-URxvt/perl-URxvt-2.2-r1.ebuild
@@ -4,6 +4,9 @@
 
 EAPI=5
 
+MY_PN="urxvt-perls"
+MY_P="${MY_PN}-${PV}"
+
 case "${PV}" in
 	(9999*)
 	KEYWORDS=""
@@ -29,6 +32,8 @@ DEPEND="dev-lang/perl"
 RDEPEND="${DEPEND}
 	x11-terms/rxvt-unicode
 	|| ( x11-misc/xsel x11-misc/xclip )"
+
+S="${WORKDIR}/${MY_P}"
 
 src_install() {
 	insinto /usr/lib/urxvt/perl/

--- a/dev-perl/perl-URxvt/perl-URxvt-9999.ebuild
+++ b/dev-perl/perl-URxvt/perl-URxvt-9999.ebuild
@@ -4,6 +4,9 @@
 
 EAPI=5
 
+MY_PN="urxvt-perls"
+MY_P="${MY_PN}-${PV}"
+
 case "${PV}" in
 	(9999*)
 	KEYWORDS=""
@@ -29,6 +32,8 @@ DEPEND="dev-lang/perl"
 RDEPEND="${DEPEND}
 	x11-terms/rxvt-unicode
 	|| ( x11-misc/xsel x11-misc/xclip )"
+
+S="${WORKDIR}/${MY_P}"
 
 src_install() {
 	insinto /usr/lib/urxvt/perl/


### PR DESCRIPTION
This fixes "The source directory '/var/tmp/portage/dev-perl/perl-URxvt-2.2/work/perl-URxvt-2.2' doesn't exist"