### PR TITLE
Update efl "expert" compilation option from -aba to -abb

### DIFF
--- a/dev-libs/efl/efl-1.17.2.ebuild
+++ b/dev-libs/efl/efl-1.17.2.ebuild
@@ -211,7 +211,7 @@ multilib_src_configure()
 		--disable-lua-old
 		--disable-multisense
 		--disable-tizen
-		--enable-i-really-know-what-i-am-doing-and-that-this-will-probably-break-things-and-i-will-fix-them-myself-and-send-patches-aba
+		--enable-i-really-know-what-i-am-doing-and-that-this-will-probably-break-things-and-i-will-fix-them-myself-and-send-patches-abb
 	)
 	autotools-utils_src_configure
 }


### PR DESCRIPTION
Hi there,
It looks like the "…-aba" option is no longer recognized, I received a very clear error message when trying to compile, and the log suggested  to use "…-abb" instead, which I successfully did.
Probably needs to be confirmed, though…
Cheers