### PR TITLE
eclass/ecnij: create symlinks for libraries in  folders

### DIFF
--- a/eclass/ecnij.eclass
+++ b/eclass/ecnij.eclass
@@ -269,6 +269,13 @@ ecnij_src_install()
 			pushd ${pr} || die
 			dir_src_command "${PRINTER_SRC[*]}" "emake" "DESTDIR=\"${D}\" install"
 			popd
+			
+			pushd ${prid}/libs_bin${abi_lib} || die
+			for lib in lib*.so; do
+				[[ -L ${lib} ]] && continue ||
+				rm ${lib} && ln -s ${lib}.[0-9]* ${lib}
+			done
+			popd
 
 			dolib.so ${prid}/libs_bin${abi_lib}/*.so*
 			exeinto /var/lib/cnijlib


### PR DESCRIPTION
After the merge of a cnijfilters ebuild I noticed that ldconfig was complaining
about some libraries (files in .so in /usr/lib64) were not symlinks. Turns out
the ebuild had merged twice the same files for a couple of .so library files.

Example you had:

```
/usr/lib64/libcnbpcnclapi429.so
/usr/lib64/libcnbpcnclapi429.so.4.0.0
```

Both of them files, of the same sizes. So the solution would be to replace the .so
file into a symlink to the .so.x.x.x file as it is customary.

Looking in the eclass I could find that apparently the problem already occured and
was fixed in the com folder. So the same fix seems to be necessary in the $PRID
folder of the printers one is installing the driver for.